### PR TITLE
chore(server): replace tdb api /referentiel/siret-uai-reseaux route by /organismes

### DIFF
--- a/server/src/common/apis/TableauDeBordApi.js
+++ b/server/src/common/apis/TableauDeBordApi.js
@@ -2,6 +2,7 @@ const RateLimitedApi = require("./RateLimitedApi");
 const { fetchStream } = require("../utils/httpUtils");
 const { compose } = require("oleoduc");
 const { streamNestedJsonArray } = require("../utils/streamUtils");
+const config = require("../../config");
 
 class TableauDeBordApi extends RateLimitedApi {
   constructor(options = {}) {
@@ -13,8 +14,12 @@ class TableauDeBordApi extends RateLimitedApi {
   }
 
   async streamReseaux() {
-    const response = await fetchStream(`${TableauDeBordApi.baseApiUrl}/referentiel/siret-uai-reseaux`, {
+    const response = await fetchStream(`${TableauDeBordApi.baseApiUrl}/organismes`, {
+      method: "POST",
       insecureHTTPParser: true,
+      data: {
+        apiKey: config.api.tableauDeBordApiKey,
+      },
     });
 
     return compose(response, streamNestedJsonArray("organismes"));

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -42,5 +42,6 @@ module.exports = {
       username: env.get("REFERENTIEL_API_ACCE_USERNAME").required().asString(),
       password: env.get("REFERENTIEL_API_ACCE_PASSWORD").required().asString(),
     },
+    tableauDeBordApiKey: env.get("TABLEAU_DE_BORD_API_KEY").required().asString(),
   },
 };

--- a/server/src/jobs/sources/tableau-de-bord.js
+++ b/server/src/jobs/sources/tableau-de-bord.js
@@ -3,8 +3,8 @@ const TableauDeBordApi = require("../../common/apis/TableauDeBordApi");
 const { uniq } = require("lodash");
 
 const RESEAU_LABELS = {
-  "cfa ec": "Enseignement catholique",
-  "compagnons-du-devoir": "Compagnons du devoir",
+  cfa_ec: "Enseignement catholique",
+  COMP_DU_DEVOIR: "Compagnons du devoir",
 };
 
 module.exports = (custom = {}) => {

--- a/server/tests/jobs/sources/tableau-de-bord-test.js
+++ b/server/tests/jobs/sources/tableau-de-bord-test.js
@@ -10,11 +10,11 @@ describe("tableau-de-bord", () => {
     await insertOrganisme({ siret: "11111111100006" });
     mockTableauDeBordApi((client, responses) => {
       client
-        .get((uri) => uri.includes("siret-uai-reseaux"))
+        .get((uri) => uri.includes("organismes"))
         .query(() => true)
         .reply(
           200,
-          responses.siretUaiReseaux({
+          responses.organismes({
             organismes: [
               {
                 siret: "11111111100006",

--- a/server/tests/jobs/sources/tableau-de-bord-test.js
+++ b/server/tests/jobs/sources/tableau-de-bord-test.js
@@ -10,11 +10,11 @@ describe("tableau-de-bord", () => {
     await insertOrganisme({ siret: "11111111100006" });
     mockTableauDeBordApi((client, responses) => {
       client
-        .get((uri) => uri.includes("organismes"))
+        .post((uri) => uri.includes("organismes"))
         .query(() => true)
         .reply(
           200,
-          responses.organismes({
+          responses.siretUaiReseaux({
             organismes: [
               {
                 siret: "11111111100006",

--- a/server/tests/utils/testConfig.js
+++ b/server/tests/utils/testConfig.js
@@ -3,3 +3,4 @@ process.env.REFERENTIEL_SIRENE_API_CONSUMER_SECRET = "secret";
 process.env.REFERENTIEL_OVH_STORAGE_URI = "http://ovh";
 process.env.REFERENTIEL_API_ACCE_USERNAME = "username";
 process.env.REFERENTIEL_API_ACCE_PASSWORD = "secret";
+process.env.TABLEAU_DE_BORD_API_KEY = "123456789";


### PR DESCRIPTION
Remplacement de la route de l'api TDB /referentiel/siret-uai-reseaux/ par /organismes avec utilisation d'une API Key & update des mapping des réseaux.