### PR TITLE
chore(server): add import tdb job with clear

### DIFF
--- a/server/src/cli.js
+++ b/server/src/cli.js
@@ -18,10 +18,26 @@ const importAcce = require("./jobs/importAcce");
 const { exportOrganismes } = require("./jobs/exportOrganismes");
 const { exportReseauxAsCsv, exportReseauxAsGraph } = require("./jobs/exportReseaux.js");
 const { streamString } = require("./common/utils/streamUtils");
+const clearOrganismesReseaux = require("./jobs/clearReseaux.js");
 
 function asArray(v) {
   return v.split(",");
 }
+
+/**
+ * Script d'import des réseaux issus du tableau de bord
+ * En amont va supprimer tous réseaux des organismes pour s'assurer que les réseaux sont bien remis à [] avant import
+ */
+cli
+  .command("import:tableau-de-bord")
+  .description("Import de tous les réseaux des organismes depuis le tableau de bord")
+  .action(() => {
+    runScript(async () => {
+      await clearOrganismesReseaux();
+      const tdbSource = createSource("tableau-de-bord");
+      return collectSources(tdbSource);
+    });
+  });
 
 cli
   .command("build")

--- a/server/src/jobs/clearReseaux.js
+++ b/server/src/jobs/clearReseaux.js
@@ -1,0 +1,14 @@
+const { dbCollection } = require("../common/db/mongodb.js");
+const logger = require("../common/logger.js");
+
+/**
+ * Fonction de suppression des réseaux des organismes
+ * Initialise les réseaux à un tableau vide
+ */
+async function clearOrganismesReseaux() {
+  logger.info("Suppression de tous les réseaux des organismes ...");
+  await dbCollection("organismes").updateMany({}, [{ $set: { reseaux: [] } }]);
+  logger.info("Suppression de tous les réseaux des organismes réalisée avec succès !");
+}
+
+module.exports = clearOrganismesReseaux;


### PR DESCRIPTION
Création d'un job dédié à l'import du tableau-de-bord en y incluant un clear des réseaux en amont pour s'assurer que les réseaux sont bien clean.