### PR TITLE
feat(server): gestion de l'authentification à l'API Catalogue via Cookie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ node_modules/
 .local/
 lib/
 .coverage/
+
+# User-specific launch
+.vscode/launch.json

--- a/server/src/cli.js
+++ b/server/src/cli.js
@@ -39,6 +39,19 @@ cli
     });
   });
 
+/**
+ * Script de collecte des données issues du catalogue
+ */
+cli
+  .command("collect:catalogue")
+  .description("Collecte des données du catalogue")
+  .action(() => {
+    runScript(async () => {
+      const catalogueSource = createSource("catalogue");
+      return collectSources(catalogueSource);
+    });
+  });
+
 cli
   .command("build")
   .description("Construit le référentiel")

--- a/server/src/common/apis/CatalogueApi.js
+++ b/server/src/common/apis/CatalogueApi.js
@@ -3,20 +3,47 @@ const { fetchStream, fetchData } = require("../utils/httpUtils");
 const { compose } = require("oleoduc");
 const convertQueryIntoParams = require("./utils/convertQueryIntoParams");
 const { streamJsonArray } = require("../utils/streamUtils");
+const config = require("../../config");
+const logger = require("../logger.js");
 
 class CatalogueApi extends RateLimitedApi {
   constructor(options = {}) {
     super("CatalogueApi", { nbRequests: 5, perSeconds: 1, ...options });
+    this.authCookie = null;
   }
 
   static get baseApiUrl() {
-    return "https://catalogue-apprentissage.intercariforef.org/api";
+    return "https://catalogue.apprentissage.education.gouv.fr/api";
+  }
+
+  async login() {
+    const response = await fetchData(`${CatalogueApi.baseApiUrl}/v1/auth/login`, {
+      method: "POST",
+      raw: true,
+      data: {
+        username: config.api.catalogue.username,
+        password: config.api.catalogue.password,
+      },
+    });
+
+    logger.info(`Le cookie d'authentification a été renouvelé`);
+    this.authCookie = response.headers["set-cookie"].join(";");
+  }
+
+  isAuthenticated() {
+    return !!this.authCookie;
   }
 
   streamFormations(query, options) {
     return this.execute(async () => {
+      if (!this.isAuthenticated()) {
+        await this.login();
+      }
+
       const params = convertQueryIntoParams(query, options);
-      const response = await fetchStream(`${CatalogueApi.baseApiUrl}/entity/formations.json?${params}`);
+      const response = await fetchStream(`${CatalogueApi.baseApiUrl}/entity/formations.json?${params}`, {
+        headers: { cookie: this.authCookie },
+      });
 
       return compose(response, streamJsonArray());
     });
@@ -24,9 +51,14 @@ class CatalogueApi extends RateLimitedApi {
 
   streamEtablissements(query, options) {
     return this.execute(async () => {
-      const params = convertQueryIntoParams(query, options);
+      if (!this.isAuthenticated()) {
+        await this.login();
+      }
 
-      const response = await fetchStream(`${CatalogueApi.baseApiUrl}/entity/etablissements.json?${params}`);
+      const params = convertQueryIntoParams(query, options);
+      const response = await fetchStream(`${CatalogueApi.baseApiUrl}/entity/etablissements.json?${params}`, {
+        headers: { cookie: this.authCookie },
+      });
 
       return compose(response, streamJsonArray());
     });
@@ -34,9 +66,14 @@ class CatalogueApi extends RateLimitedApi {
 
   getEtablissement(query, options) {
     return this.execute(async () => {
-      const params = convertQueryIntoParams(query, options);
+      if (!this.isAuthenticated()) {
+        await this.login();
+      }
 
-      return fetchData(`${CatalogueApi.baseApiUrl}/entity/etablissement?${params}`);
+      const params = convertQueryIntoParams(query, options);
+      return fetchData(`${CatalogueApi.baseApiUrl}/entity/etablissement?${params}`, {
+        headers: { cookie: this.authCookie },
+      });
     });
   }
 }

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -42,6 +42,10 @@ module.exports = {
       username: env.get("REFERENTIEL_API_ACCE_USERNAME").required().asString(),
       password: env.get("REFERENTIEL_API_ACCE_PASSWORD").required().asString(),
     },
+    catalogue: {
+      username: env.get("CATALOGUE_API_USERNAME").required().asString(),
+      password: env.get("CATALOGUE_API_PASSWORD").required().asString(),
+    },
     tableauDeBordApiKey: env.get("TABLEAU_DE_BORD_API_KEY").required().asString(),
     tableauDeBordApiUrl: env.get("TABLEAU_DE_BORD_PUBLIC_URL").required().asString(),
   },

--- a/server/tests/utils/apiMocks.js
+++ b/server/tests/utils/apiMocks.js
@@ -17,6 +17,10 @@ function createNock(baseUrl) {
 module.exports = {
   mockCatalogueApi(callback) {
     const client = createNock(CatalogueApi.baseApiUrl);
+
+    // Mock login cookie
+    client.post((uri) => uri.includes("v1/auth/login")).reply(200, "OK", { "Set-Cookie": "sampleCookie" });
+
     callback(client, {
       formations(array = [{}]) {
         return array.map((custom) => {

--- a/server/tests/utils/testConfig.js
+++ b/server/tests/utils/testConfig.js
@@ -5,3 +5,5 @@ process.env.REFERENTIEL_API_ACCE_USERNAME = "username";
 process.env.REFERENTIEL_API_ACCE_PASSWORD = "secret";
 process.env.TABLEAU_DE_BORD_API_KEY = "123456789";
 process.env.TABLEAU_DE_BORD_PUBLIC_URL = "https://cfas.apprentissage.beta.gouv.fr/api";
+process.env.CATALOGUE_API_USERNAME = "referentiel-user";
+process.env.CATALOGUE_API_PASSWORD = "CatalogApiPasswordTest";


### PR DESCRIPTION
Pour récupérer les uai de formation il est désormais nécessaire de s'authentifier à l'API Catalogue (via une autre URL) avec un mécanisme par cookie.

- Ajout de variables à la config 👉🏼 https://github.com/mission-apprentissage/referentiel/pull/114/commits/a4921d1a31e16bd7e197f92c4c902a0bc934c933
- Modification de l'API Catalogue pour gérer le mécanisme d'authent et nouvelle URL 👉🏼 https://github.com/mission-apprentissage/referentiel/pull/114/commits/0e99b0a57ae320348e2d6277fe08a091f6e6582e
- Modification de la config des tests 👉🏼 https://github.com/mission-apprentissage/referentiel/pull/114/commits/6f96c6ab929d1c73879dcb8be720336544d6dd0d
- Modification du mécanisme de nock 👉🏼 https://github.com/mission-apprentissage/referentiel/pull/114/commits/641ccbf2e65b795857373190ba901d594b0d24c0


_J'ai aussi découpé la collecte des données catalogue dans un job via CLI indépendant au cas ou l'on aurait besoin de le lancer unitairement._

_J'ai aussi ajouté un fichier au .gitIgnore car j'ai du débugger en local via VsCode pour tester qqs élements._