### PR TITLE
feat(server): filtrage des uai de lieux de formation fiables en fonction des statuts affelnet/parcoursup

### DIFF
--- a/server/src/common/catalogStatuts.js
+++ b/server/src/common/catalogStatuts.js
@@ -1,0 +1,9 @@
+const CATALOG_COMMON_STATUS = {
+  HORS_PERIMETRE: /** @type {CommonStatus} */ ("hors périmètre"),
+  PUBLIE: /** @type {CommonStatus} */ ("publié"),
+  NON_PUBLIE: /** @type {CommonStatus} */ ("non publié"),
+  A_PUBLIER: /** @type {CommonStatus} */ ("à publier"),
+  EN_ATTENTE: /** @type {CommonStatus} */ ("en attente de publication"),
+};
+
+module.exports = { CATALOG_COMMON_STATUS };

--- a/server/src/common/db/collections/organismes.js
+++ b/server/src/common/db/collections/organismes.js
@@ -91,6 +91,7 @@ module.exports = {
               code: string(),
               siret: string(),
               uai: string(),
+              uai_fiable: boolean(),
               adresse: adresseSchema,
               sources: arrayOf(string()),
               date_collecte: date(),

--- a/ui/src/organismes/fiche/lieux/LieuxDeFormationTab.jsx
+++ b/ui/src/organismes/fiche/lieux/LieuxDeFormationTab.jsx
@@ -5,7 +5,8 @@ import { Table, Thead } from "../../../common/dsfr/elements/Table.jsx";
 import NA from "../../../common/organismes/NA.jsx";
 
 export default function LieuxDeFormationTab({ organisme }) {
-  const nbLieux = organisme.lieux_de_formation.length;
+  const lieuxDeFormationFiables = organisme.lieux_de_formation.filter((item) => item.uai_fiable);
+  const nbLieux = lieuxDeFormationFiables.length;
 
   return (
     <>
@@ -31,7 +32,7 @@ export default function LieuxDeFormationTab({ organisme }) {
               </Thead>
             }
           >
-            {organisme.lieux_de_formation.map((lieu) => {
+            {lieuxDeFormationFiables.map((lieu) => {
               return (
                 <tr key={lieu.code}>
                   <td>{lieu.uai ? lieu.uai : <NA />}</td>


### PR DESCRIPTION
Les UAI des lieux de formation dans le référentiel ne sont pas toujours fiables.
Vu avec @QuentinPetel on pars du principe que les UAI de formation traitées par les instructeurs sont fiables et les autres non.
Du coup dans le référentiel je prévois de : 

- [ ] Remonter les champs **parcoursup_statut** et **affelnet_statut**
- [ ] Ajouter une information **uai_lieu_fiable** en fonction de la valeurs des champs **affelnet_statut** / **parcoursup_statut**
- [ ] N'afficher dans l'UI que les lieux ayant le champ **uai_lieu_fiable  = true**
