### PR TITLE
[UI] Corriger le bug rendant impossible la sélection d'UAI

### DIFF
--- a/ui/src/common/dsfr/elements/Modal.jsx
+++ b/ui/src/common/dsfr/elements/Modal.jsx
@@ -1,4 +1,3 @@
-import { classNames } from "../dsfr";
 import React from "react";
 import useElementId from "../../hooks/useElementId";
 import { Button } from "./Button";
@@ -10,24 +9,23 @@ export const modalSizeModifiers = {
 };
 
 export default function Modal({ title, modal, content, footer, size, modifiers, className, ...rest }) {
-  const clazz = classNames("fr-col", { modifiers: modifiers || modalSizeModifiers.md, className, bemDelimiter: "-" });
   const contentId = useElementId("modal-content");
 
   return (
     <dialog className={"fr-modal"} id={modal.id} ref={modal.ref} aria-labelledby={contentId} role="dialog" {...rest}>
-      <div className="fr-container fr-container--fluid fr-container-md">
-        <div className="fr-grid-row fr-grid-row--center">
-          <div className={clazz}>
-            <div className="fr-modal__body">
-              <div className="fr-modal__header">
-                <Button modifiers={"close"} aria-controls={modal.id} title="Fermer" onClick={modal.close}>
+      <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+          <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+            <div class="fr-modal__body">
+              <div class="fr-modal__header">
+                <Button class="fr-link--close fr-link" aria-controls="fr-modal-2">
                   Fermer
                 </Button>
               </div>
-              <div className="fr-modal__content" id={contentId}>
-                {content}
+              <div class="fr-modal__content">
+                <p>{content}</p>
               </div>
-              <div className="fr-modal__footer">{footer}</div>
+              <div class="fr-modal__footer">{footer}</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Cette PR corrige cette [issue](https://github.com/mission-apprentissage/referentiel/issues/103). La sélection d'un UAI n'était plus possible. Le correctif s'est fait en prenant [l'exemple](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/modale) d'utilisation d'une modale dans la documentation du DSFR.

Avant:

https://user-images.githubusercontent.com/12133306/231781944-03c8c1d5-483c-4c30-a5f9-c864489bd92c.mov

Après:

https://user-images.githubusercontent.com/12133306/231782260-29ce3d0d-0ffd-4d7e-94eb-66f2880a9576.mov


