### PR TITLE
fix(server): discriminant uai lieux array

### DIFF
--- a/server/src/jobs/collectSources.js
+++ b/server/src/jobs/collectSources.js
@@ -216,7 +216,7 @@ module.exports = async (array, options = {}) => {
                 contacts: mergeContacts(from, organisme.contacts, contacts),
                 diplomes: _mergeArray(from, organisme.diplomes, diplomes, "code"),
                 certifications: _mergeArray(from, organisme.certifications, certifications, "code"),
-                lieux_de_formation: _mergeArray(from, organisme.lieux_de_formation, lieux_de_formation, "code"),
+                lieux_de_formation: _mergeArray(from, organisme.lieux_de_formation, lieux_de_formation, "uai"),
                 reseaux: _mergeArray(from, organisme.reseaux, reseaux, "code"),
               }),
             }


### PR DESCRIPTION
Correction de la construction des UAI lieux en passant le discriminant sur l'UAI.
On avait des doublons et certains UAI lieux passaient à la trappe car le discriminant était fait sur le code qui est la position (longitude / latitude)