### PR TITLE
[UI] Répare la modale pour firefox

### DIFF
--- a/ui/src/common/dsfr/elements/Modal.jsx
+++ b/ui/src/common/dsfr/elements/Modal.jsx
@@ -8,19 +8,24 @@ export const modalSizeModifiers = {
   lg: "md-8",
 };
 
-export default function Modal({ title, modal, content, footer, size, modifiers, className, ...rest }) {
+export default function Modal({ title, modal, content, footer, size, modifiers, className, closeModal, ...rest }) {
   const contentId = useElementId("modal-content");
 
   return (
-    <dialog className={"fr-modal"} id={modal.id} ref={modal.ref} aria-labelledby={contentId} role="dialog" {...rest}>
+    <dialog className={"fr-modal"} id={modal.id} ref={modal.ref} aria-labelledby={contentId} {...rest}>
       <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
           <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
             <div class="fr-modal__body">
               <div class="fr-modal__header">
-                <Button class="fr-link--close fr-link" aria-controls="fr-modal-2">
+                <p
+                  class="fr-link--close fr-link"
+                  aria-controls="fr-modal-2"
+                  onClick={closeModal}
+                  style={{ cursor: "pointer" }}
+                >
                   Fermer
-                </Button>
+                </p>
               </div>
               <div class="fr-modal__content">
                 <p>{content}</p>

--- a/ui/src/organismes/fiche/Identite/DatagouvModal.jsx
+++ b/ui/src/organismes/fiche/Identite/DatagouvModal.jsx
@@ -18,6 +18,7 @@ export default function DatagouvModal({ modal, siret }) {
       title={"UAI"}
       modal={modal}
       modifiers={modalSizeModifiers.lg}
+      closeModal={modal.close}
       content={
         <>
           <h1 className="fr-modal__title">

--- a/ui/src/organismes/fiche/Identite/uai/UAISelectorModal.jsx
+++ b/ui/src/organismes/fiche/Identite/uai/UAISelectorModal.jsx
@@ -76,6 +76,7 @@ export function UAISelectorModal({ modal, organisme, action }) {
       <Modal
         title={"UAI"}
         modal={modal}
+        closeModal={modal.close}
         content={
           <>
             <h1 className="fr-modal__title">

--- a/ui/src/organismes/fiche/relations/RelationModal.jsx
+++ b/ui/src/organismes/fiche/relations/RelationModal.jsx
@@ -19,6 +19,7 @@ export default function RelationModal({ modal, organisme }) {
       title={"UAI"}
       modal={modal}
       modifiers={modalSizeModifiers.lg}
+      closeModal={modal.close}
       content={
         organisme ? (
           <>


### PR DESCRIPTION
Cette PR répare la modale pour firefox. L'usage d'un `<button>` pour la fermeture posait le soucis.
Je l'ai remplacé par du texte et une callback pour la fermeture de la modale.
Ce fix fonctionne sur les différents navigateurs.