### PR TITLE
Fix/recherche siren

### DIFF
--- a/server/src/http/routes/organismesRoutes.js
+++ b/server/src/http/routes/organismesRoutes.js
@@ -59,6 +59,11 @@ module.exports = () => {
     return query;
   }
 
+  /** Supprime les caractères spéciaux pour une expression régulière */
+  function escapeRegex(input) {
+    return input.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+  }
+
   function buildQuery(params) {
     const {
       sirets,
@@ -111,7 +116,9 @@ module.exports = () => {
           : { "uai_potentiels.uai": { $in: uai_potentiels } }
         : {}),
       ...(hasValue(etat_administratif) ? { etat_administratif } : {}),
-      ...(hasValue(text) ? { $text: { $search: text } } : {}),
+      ...(hasValue(text)
+        ? { $or: [{ $text: { $search: text } }, { siret: { $regex: new RegExp(`^${escapeRegex(text)}\\s*\\d{5}$`) } }] }
+        : {}),
       ...(hasValue(anomalies) ? { "_meta.anomalies.0": { $exists: anomalies } } : {}),
       ...(hasValue(qualiopi) ? { qualiopi } : {}),
       ...(hasValue(nouveaux)

--- a/ui/src/common/organismes/liste/SearchForm.jsx
+++ b/ui/src/common/organismes/liste/SearchForm.jsx
@@ -12,7 +12,7 @@ export default function SearchForm({ onSubmit }) {
         name="text"
         modifiers={"lg"}
         label={"Rechercher"}
-        placeholder={"Rechercher une raison sociale, une UAI, un SIRET."}
+        placeholder={"Rechercher une raison sociale, une UAI, un SIRET / SIREN."}
         {...registerField("text")}
       />
     </form>


### PR DESCRIPTION
Cette modification vise à permettre de rechercher des organismes par leur SIREN dans le champ de recherche général.

Pour ce faire, on ajoute un critère connecté par un "OU" logique au critère existant : rechercher, à l'aide d'une expression régulière, les SIRET de la forme : (valeur saisie) + espaces blancs optionnels + 5 chiffres.

Avant d'être utilisée dans l'expression régulière, la valeur saisie est débarrassée des caractères spéciaux, par précaution.